### PR TITLE
add CQL collection support

### DIFF
--- a/src/test/java/com/spotify/hdfs2cass/cassandra/utils/CassandraRecordUtilsTest.java
+++ b/src/test/java/com/spotify/hdfs2cass/cassandra/utils/CassandraRecordUtilsTest.java
@@ -1,0 +1,52 @@
+package com.spotify.hdfs2cass.cassandra.utils;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
+import org.apache.cassandra.serializers.DecimalSerializer;
+import org.apache.cassandra.serializers.FloatSerializer;
+import org.apache.cassandra.serializers.Int32Serializer;
+import org.apache.cassandra.serializers.ListSerializer;
+import org.apache.cassandra.serializers.MapSerializer;
+import org.apache.cassandra.serializers.SetSerializer;
+import org.apache.cassandra.serializers.UTF8Serializer;
+import org.junit.Test;
+
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+
+public class CassandraRecordUtilsTest {
+
+  @Test
+  public void testSerializeMap() {
+    Map<String, Integer> map = ImmutableMap.of("foo", 1, "bar", 2);
+
+    ByteBuffer expected =
+        MapSerializer.getInstance(UTF8Serializer.instance, Int32Serializer.instance).serialize(map);
+    assertEquals(expected, CassandraRecordUtils.toByteBuffer(map));
+  }
+
+  @Test
+  public void testSerializeList() {
+    List<BigDecimal> list = ImmutableList.of(BigDecimal.valueOf(0),
+                                             new BigDecimal("1.2"),
+                                             new BigDecimal("3.4"));
+
+    ByteBuffer expected = ListSerializer.getInstance(DecimalSerializer.instance).serialize(list);
+    assertEquals(expected, CassandraRecordUtils.toByteBuffer(list));
+  }
+
+  @Test
+  public void testSerializeSet() {
+    Set<Float> set = ImmutableSet.of(1.0f, 2.0f, 3.0f);
+    ByteBuffer expected = SetSerializer.getInstance(FloatSerializer.instance).serialize(set);
+    assertEquals(expected, CassandraRecordUtils.toByteBuffer(set));
+  }
+
+}


### PR DESCRIPTION
This change adds support for CQL collections (Sets, Lists, Maps) for
jobs that return CQLRecords.

The support is implemented by re-using the TypeSerializer
implementations from within Cassandra itself.

In order to serialize a collection, the serializer for the element type
needs to be known as well - it is a bit hacky but the current solution
involves peeking at the first element in the collection to get it's
runtime type, and retrieving a TypeSerializer from a Map within
CassandraRecordUtils.

In implementing this I noticed that the serialization of Collections has
changed between V2 and V3 of the CQL protocol. V3 is only supported by
Cassandra v2.1 so far, while V2 is understood by v2.0 (Cassandra v2.1
should support protocol V2 also).

Since this implementation reuses the TypeSerializers from within
cassandra-all:2.0.11:jar, it is implicitly using V2 of the protocol
format. This should be fine as long as the target Cassandra server is
using v2.0. I have not tested using these serializers when exporting to
Cassandra v1.x or v2.1+.