### PR TITLE
throw a better exception if requested CF not found

### DIFF
--- a/src/main/java/com/spotify/hdfs2cass/cassandra/utils/CassandraClusterInfo.java
+++ b/src/main/java/com/spotify/hdfs2cass/cassandra/utils/CassandraClusterInfo.java
@@ -72,6 +72,12 @@ public class CassandraClusterInfo implements Serializable {
     // ask for some metadata
     Metadata clusterMetadata = cluster.getMetadata();
     TableMetadata tableMetadata = clusterMetadata.getKeyspace(keyspace).getTable(columnFamily);
+    if (tableMetadata == null) {
+      throw new IllegalArgumentException(String.format(
+          "Requested columnfamily '%s' does not exist in keyspace '%s'!",
+          columnFamily,
+          keyspace));
+    }
     columns = tableMetadata.getColumns();
     cqlSchema = tableMetadata.asCQLQuery();
 


### PR DESCRIPTION
If someone tries to import data to a cassandra column family that
doesn't actually exist (maybe they forgot to create the table), the
Crunch job fails with a NullPointerException at the
`tableMetadata.getColumns()` line since there is no metadata for the
table. Throw a more descriptive error message in this case.
