### PR TITLE
adjust when "streaming finished successfully" is logged

### DIFF
--- a/src/main/java/com/spotify/hdfs2cass/cassandra/cql/CrunchCqlBulkRecordWriter.java
+++ b/src/main/java/com/spotify/hdfs2cass/cassandra/cql/CrunchCqlBulkRecordWriter.java
@@ -152,7 +152,12 @@ public class CrunchCqlBulkRecordWriter extends AbstractBulkRecordWriter<Object, 
         Future<StreamState> future =
             loader.stream(Collections.<InetAddress>emptySet(), new ProgressIndicator());
         try {
-          Uninterruptibles.getUninterruptibly(future);
+          StreamState streamState = Uninterruptibles.getUninterruptibly(future);
+          if (streamState.hasFailedSession()) {
+            LOG.warn("Some streaming sessions failed");
+          } else {
+            LOG.info("Streaming finished successfully");
+          }
         } catch (ExecutionException e) {
           throw new RuntimeException("Streaming to the following hosts failed: " +
               loader.getFailedHosts(), e);
@@ -163,7 +168,5 @@ public class CrunchCqlBulkRecordWriter extends AbstractBulkRecordWriter<Object, 
     } finally {
       heartbeat.stopHeartbeat();
     }
-    LOG.info("Streaming finished successfully");
   }
-
 }

--- a/src/main/java/com/spotify/hdfs2cass/cassandra/thrift/CrunchBulkRecordWriter.java
+++ b/src/main/java/com/spotify/hdfs2cass/cassandra/thrift/CrunchBulkRecordWriter.java
@@ -227,7 +227,12 @@ public class CrunchBulkRecordWriter
         Future<StreamState> future =
             loader.stream(Collections.<InetAddress>emptySet(), new ProgressIndicator());
         try {
-          Uninterruptibles.getUninterruptibly(future);
+          StreamState streamState = Uninterruptibles.getUninterruptibly(future);
+          if (streamState.hasFailedSession()) {
+            LOG.warn("Some streaming sessions failed");
+          } else {
+            LOG.info("Streaming finished successfully");
+          }
         } catch (ExecutionException e) {
           throw new RuntimeException("Streaming to the following hosts failed: " +
               loader.getFailedHosts(), e);


### PR DESCRIPTION
If the BulkRecordWriter is closed due to GC errors / the task shutting
down, the "streaming finished successfully" message is logged
unconditionally, which might be confusing (especially when logging in
concert with "no streaming happened").