### PR TITLE
Fix import for keyspaces & column families with upper case names

### DIFF
--- a/src/main/java/com/spotify/hdfs2cass/cassandra/utils/CassandraClusterInfo.java
+++ b/src/main/java/com/spotify/hdfs2cass/cassandra/utils/CassandraClusterInfo.java
@@ -73,8 +73,8 @@ public class CassandraClusterInfo implements Serializable {
     // ask for some metadata
     try {
       Metadata clusterMetadata = cluster.getMetadata();
-      KeyspaceMetadata keyspaceMetadata = clusterMetadata.getKeyspace(keyspace);
-      TableMetadata tableMetadata = keyspaceMetadata.getTable(columnFamily);
+      KeyspaceMetadata keyspaceMetadata = clusterMetadata.getKeyspace('"' + keyspace + '"');
+      TableMetadata tableMetadata = keyspaceMetadata.getTable('"' + columnFamily + '"');
       columns = tableMetadata.getColumns();
       cqlSchema = tableMetadata.asCQLQuery();
       partitionerClass = clusterMetadata.getPartitioner();


### PR DESCRIPTION
As of CQL 3.0, the cassandra driver will down case ids names that aren't quoted. This will prevent CasandraClusterInfo#init from finding the target keyspace & column family  if the actual ids contain any capitals.

See here:
http://docs.datastax.com/en/cql/3.0/cql/cql_reference/ucase-lcase_r.html

https://github.com/datastax/java-driver/blob/2b5a681/driver-core/src/main/java/com/datastax/driver/core/Metadata.java#L212

https://github.com/datastax/java-driver/blob/2b5a681/driver-core/src/main/java/com/datastax/driver/core/Metadata.java#L312