### PR TITLE
Add conversion of UUID to byte buffer

### DIFF
--- a/src/main/java/com/spotify/hdfs2cass/cassandra/utils/CassandraRecordUtils.java
+++ b/src/main/java/com/spotify/hdfs2cass/cassandra/utils/CassandraRecordUtils.java
@@ -107,6 +107,8 @@ public final class CassandraRecordUtils implements Serializable {
       return serializeSet((Set<?>) value);
     } else if (value instanceof List) {
       return serializeList((List<?>) value);
+    } else if (value instanceof UUID) {
+      return ByteBufferUtil.bytes((UUID) value);
     }
 
 


### PR DESCRIPTION
Allow UUID values to be converted to bytebuffer. Seems to be an oversight.