### PR TITLE
JCommander works with instance fields not class fields.

### DIFF
--- a/src/main/java/com/spotify/hdfs2cass/Hdfs2Cass.java
+++ b/src/main/java/com/spotify/hdfs2cass/Hdfs2Cass.java
@@ -63,22 +63,22 @@ import java.util.List;
 public class Hdfs2Cass extends Configured implements Tool, Serializable {
 
   @Parameter(names = "--input", required = true)
-  protected static List<String> input;
+  protected List<String> input;
 
   @Parameter(names = "--output", required = true)
-  protected static String output;
+  protected String output;
 
   @Parameter(names = "--rowkey")
-  protected static String rowkey = "rowkey";
+  protected String rowkey = "rowkey";
 
   @Parameter(names = "--timestamp")
-  protected static String timestamp;
+  protected String timestamp;
 
   @Parameter(names = "--ttl")
-  protected static String ttl;
+  protected String ttl;
 
   @Parameter(names = "--ignore")
-  protected static List<String> ignore = Lists.newArrayList();
+  protected List<String> ignore = Lists.newArrayList();
 
   public static void main(String[] args) throws Exception {
     // Logging for local runs. Causes duplicate log lines on actual Hadoop cluster

--- a/src/main/java/com/spotify/hdfs2cass/LegacyHdfs2Cass.java
+++ b/src/main/java/com/spotify/hdfs2cass/LegacyHdfs2Cass.java
@@ -60,10 +60,10 @@ import java.util.List;
 public class LegacyHdfs2Cass extends Configured implements Tool, Serializable {
 
   @Parameter(names = "--input", required = true)
-  protected static List<String> input;
+  protected List<String> input;
 
   @Parameter(names = "--output", required = true)
-  protected static String output;
+  protected String output;
 
 
   public static void main(String[] args) throws Exception {


### PR DESCRIPTION
We have observed in other projects that class fields used for JCommander can cause issues.