### PR TITLE
Sort reducer input records in sstable order

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,6 @@ The format of the output URI is:
 The protocols in the output URI can be either `cql` or `thrift`. They are used to determine what type of C\* column family the data is imported into. The `port` is the binary protocol port C\* listens to client connections on.
 
 The `params...` are all optional. They can be:
-   * `buffersize=N` - Size of temporary SSTables built before streaming. Example `buffersize=64` will cause SSTables of size 64 MB to be built.
    * `columnnames=N1,N2` - Relevant for CQL. Used to override inferred order of columns in the prepared insert statement. See [this](src/main/java/com/spotify/hdfs2cass/crunch/cql/CQLRecord.java) for more info.
    * `compressionclass=S` - What compression to use when building SSTables. Defaults to whichever the table was created with.
    * `copiers=N` - The default number of parallel transfers run by reduce during the copy (shuffle) phase. Defaults to 5.

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,13 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-junit</artifactId>
+            <version>2.0.0.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/spotify/hdfs2cass/cassandra/cql/CrunchCqlBulkRecordWriter.java
+++ b/src/main/java/com/spotify/hdfs2cass/cassandra/cql/CrunchCqlBulkRecordWriter.java
@@ -73,7 +73,7 @@ public class CrunchCqlBulkRecordWriter extends AbstractBulkRecordWriter<Object, 
     heartbeat = new ProgressHeartbeat(context, 120);
   }
 
-  private void setConfigs() 
+  private void setConfigs()
   {
     // if anything is missing, exceptions will be thrown here, instead of on write()
     keyspace = ConfigHelper.getOutputKeyspace(conf);
@@ -91,7 +91,7 @@ public class CrunchCqlBulkRecordWriter extends AbstractBulkRecordWriter<Object, 
             .using(insertStatement)
             .withPartitioner(ConfigHelper.getOutputPartitioner(conf))
             .inDirectory(outputDir)
-            .withBufferSizeInMB(Integer.parseInt(conf.get(BUFFER_SIZE_IN_MB, "64")))
+            .sorted()
             .build();
       }
       if (loader == null) {

--- a/src/main/java/com/spotify/hdfs2cass/cassandra/utils/CassandraKeyComparator.java
+++ b/src/main/java/com/spotify/hdfs2cass/cassandra/utils/CassandraKeyComparator.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2016 Spotify AB. All rights reserved.
+ *
+ * The contents of this file are licensed under the Apache License, Version
+ * 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.hdfs2cass.cassandra.utils;
+
+import com.google.common.base.Throwables;
+import org.apache.avro.io.BinaryDecoder;
+import org.apache.avro.io.DecoderFactory;
+import org.apache.avro.mapred.AvroKey;
+import org.apache.cassandra.dht.IPartitioner;
+import org.apache.hadoop.conf.Configurable;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.RawComparator;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+/**
+ * A comparator for sorting keys in sstable order. This is used in the shuffle
+ * to ensure that the reducer sees inputs in the correct order and can append
+ * them to sstables without sorting again.
+ */
+public class CassandraKeyComparator implements RawComparator<AvroKey<ByteBuffer>>, Configurable {
+  private static final DecoderFactory DECODER_FACTORY = DecoderFactory.get();
+
+  private Configuration conf;
+  private IPartitioner<?> partitioner;
+
+  @Override
+  public int compare(byte[] o1, int s1, int l1, byte[] o2, int s2, int l2) {
+    try {
+      final BinaryDecoder d1 = DECODER_FACTORY.binaryDecoder(o1, s1, l1, null);
+      final ByteBuffer key1 = d1.readBytes(null);
+
+      // re-use the decoder instance, but do not re-use the byte buffer,
+      // because DecoratedKey stores a reference
+      final BinaryDecoder d2 = DECODER_FACTORY.binaryDecoder(o2, s2, l2, d1);
+      final ByteBuffer key2 = d2.readBytes(null);
+
+      return compare(key1, key2);
+    } catch (final IOException e) {
+      throw Throwables.propagate(e);
+    }
+  }
+
+  @Override
+  public int compare(AvroKey<ByteBuffer> o1, AvroKey<ByteBuffer> o2) {
+    final ByteBuffer key1 = o1.datum();
+    final ByteBuffer key2 = o2.datum();
+    return compare(key1, key2);
+  }
+
+  private int compare(final ByteBuffer key1, final ByteBuffer key2) {
+    assert key1 != key2 : "bug - unsafe buffer re-use";
+    return partitioner.decorateKey(key1).compareTo(partitioner.decorateKey(key2));
+  }
+
+  @Override
+  public Configuration getConf() {
+    return conf;
+  }
+
+  @Override
+  public void setConf(Configuration conf) {
+    this.conf = conf;
+    final String partitionerParam = conf.get(CassandraParams.SCRUB_CASSANDRACLUSTER_PARTITIONER_CONFIG);
+    if (partitionerParam == null) {
+      throw new RuntimeException("Didn't get any cassandra partitioner information");
+    }
+    try {
+      partitioner = (IPartitioner<?>) Class.forName(partitionerParam).newInstance();
+    } catch (final Exception e) {
+      throw Throwables.propagate(e);
+    }
+  }
+}

--- a/src/test/java/com/spotify/hdfs2cass/cassandra/utils/CassandraKeyComparatorTest.java
+++ b/src/test/java/com/spotify/hdfs2cass/cassandra/utils/CassandraKeyComparatorTest.java
@@ -1,0 +1,90 @@
+/*
+/*
+ * Copyright 2016 Spotify AB. All rights reserved.
+ *
+ * The contents of this file are licensed under the Apache License, Version
+ * 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.hdfs2cass.cassandra.utils;
+
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+
+import org.apache.avro.io.BinaryEncoder;
+import org.apache.avro.io.EncoderFactory;
+import org.apache.cassandra.dht.Murmur3Partitioner;
+import org.apache.cassandra.dht.OrderPreservingPartitioner;
+import org.apache.hadoop.conf.Configuration;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+public class CassandraKeyComparatorTest {
+  private static final EncoderFactory ENCODERS = EncoderFactory.get();
+
+  private final CassandraKeyComparator comparator = new CassandraKeyComparator();
+  private final Configuration conf = new Configuration();
+
+  @Test
+  public void compareOrderPreservingPartitioner() throws IOException {
+    conf.set(CassandraParams.SCRUB_CASSANDRACLUSTER_PARTITIONER_CONFIG,
+        OrderPreservingPartitioner.class.getName());
+    comparator.setConf(conf);
+    checkOrder("abc", "def");
+    checkOrder("1", "2");
+    checkOrder("abc1", "abc2");
+    checkOrder("abc", "abcdef");
+  }
+
+  @Test
+  public void compareMurmur3Partitioner() throws IOException {
+    conf.set(CassandraParams.SCRUB_CASSANDRACLUSTER_PARTITIONER_CONFIG,
+        Murmur3Partitioner.class.getName());
+    comparator.setConf(conf);
+    // murmur3_128("foo")[0] = -2129773440516405919
+    // murmur3_128("bar")[0] = -7911037993560119804
+    // murmur3_128("baz")[0] = 8295379539955784970
+    checkOrder("bar", "foo");
+    checkOrder("foo", "baz");
+    checkOrder("bar", "baz");
+
+    // Murmur3Partitioner maps empty string to Long.MIN_VALUE
+    checkOrder("", "foo");
+    checkOrder("", "bar");
+  }
+
+  private void checkOrder(final String key1, final String key2) throws IOException {
+    final byte[] buf1 = bytes(key1, 0);
+    final int offset = 3;
+    final byte[] buf2 = bytes(key2, offset);
+
+    final int l1 = buf1.length;
+    final int l2 = buf2.length - offset;
+    assertThat(comparator.compare(buf1, 0, l1, buf2, offset, l2), lessThan(0));
+    assertThat(comparator.compare(buf2, offset, l2, buf1, 0, l1), greaterThan(0));
+    assertThat(comparator.compare(buf1, 0, l1, buf1, 0, l1), is(0));
+    assertThat(comparator.compare(buf2, offset, l2, buf2, offset, l2), is(0));
+  }
+
+  private static byte[] bytes(final String s, final int offset)
+      throws IOException {
+    final ByteArrayOutputStream baos = new ByteArrayOutputStream(32);
+    baos.write(new byte[offset], 0, offset);
+    final BinaryEncoder enc = ENCODERS.directBinaryEncoder(baos, null);
+    enc.writeString(s);
+    return baos.toByteArray();
+  }
+}


### PR DESCRIPTION
Using a custom key sort in the shuffle phase, we can ensure that the
reducer sees records in the correct order (Cassandra partitioner
order). This lets us append records directly to sstables without
buffering and sorting in reducer memory.