### PR TITLE
Infer partitioning keys from CQL records

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.spotify.hdfs2cass</groupId>
     <artifactId>spotify-hdfs2cass</artifactId>
-    <version>2.12</version>
+    <version>2.13-SNAPSHOT</version>
     <name>${project.groupId}:${project.artifactId}</name>
 
     <description>

--- a/src/main/java/com/spotify/hdfs2cass/Hdfs2Cass.java
+++ b/src/main/java/com/spotify/hdfs2cass/Hdfs2Cass.java
@@ -31,6 +31,7 @@ import org.apache.crunch.Pipeline;
 import org.apache.crunch.PipelineResult;
 import org.apache.crunch.impl.mr.MRPipeline;
 import org.apache.crunch.io.From;
+import org.apache.crunch.types.avro.Avros;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.Configured;
 import org.apache.hadoop.fs.Path;
@@ -121,7 +122,7 @@ public class Hdfs2Cass extends Configured implements Tool, Serializable {
       records
           // In case of CQL, convert ByteBuffers to CQLRecords
           .parallelDo(new AvroToCQL(rowkey, timestamp, ttl, ignore), CQLRecord.PTYPE)
-          .parallelDo(new CQLRecord.AsPair(), CQLRecord.AsPair.PTYPE)
+          .by(params.getKeyFn(), Avros.bytes())
           .groupByKey(params.createGroupingOptions())
           .write(new CQLTarget(outputUri, params));
     }

--- a/src/main/java/com/spotify/hdfs2cass/LegacyHdfs2Cass.java
+++ b/src/main/java/com/spotify/hdfs2cass/LegacyHdfs2Cass.java
@@ -30,7 +30,6 @@ import org.apache.crunch.Pipeline;
 import org.apache.crunch.PipelineResult;
 import org.apache.crunch.impl.mr.MRPipeline;
 import org.apache.crunch.io.From;
-import org.apache.crunch.io.avro.AvroFileSource;
 import org.apache.crunch.types.avro.Avros;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.Configured;
@@ -105,7 +104,7 @@ public class LegacyHdfs2Cass extends Configured implements Tool, Serializable {
       records
           // In case of CQL, convert ByteBuffers to CQLRecords
           .parallelDo(new LegacyHdfsToCQL(), CQLRecord.PTYPE)
-          .parallelDo(new CQLRecord.AsPair(), CQLRecord.AsPair.PTYPE)
+          .by(params.getKeyFn(), Avros.bytes())
           .groupByKey(params.createGroupingOptions())
           .write(new CQLTarget(outputUri, params));
     }

--- a/src/main/java/com/spotify/hdfs2cass/cassandra/cql/CrunchCqlBulkOutputFormat.java
+++ b/src/main/java/com/spotify/hdfs2cass/cassandra/cql/CrunchCqlBulkOutputFormat.java
@@ -21,6 +21,7 @@
  */
 package com.spotify.hdfs2cass.cassandra.cql;
 
+import com.spotify.hdfs2cass.crunch.cql.CQLRecord;
 import org.apache.cassandra.hadoop.AbstractBulkOutputFormat;
 import org.apache.crunch.CrunchRuntimeException;
 import org.apache.hadoop.conf.Configuration;
@@ -31,7 +32,6 @@ import org.apache.hadoop.util.Progressable;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.List;
 
 /**
  * This is an almost-copy of {@link org.apache.cassandra.hadoop.cql3.CqlBulkOutputFormat}
@@ -41,7 +41,7 @@ import java.util.List;
  * https://issues.apache.org/jira/browse/CASSANDRA-8367
  * </p>
  */
-public class CrunchCqlBulkOutputFormat extends AbstractBulkOutputFormat<Object, List<ByteBuffer>> {
+public class CrunchCqlBulkOutputFormat extends AbstractBulkOutputFormat<ByteBuffer, CQLRecord> {
 
   private static final String OUTPUT_CQL_SCHEMA_PREFIX = "cassandra.columnfamily.schema.";
   private static final String OUTPUT_CQL_INSERT_PREFIX = "cassandra.columnfamily.insert.";
@@ -51,6 +51,7 @@ public class CrunchCqlBulkOutputFormat extends AbstractBulkOutputFormat<Object, 
    * Not used anyway, so do not bother implementing.
    */
   @Deprecated
+  @Override
   public CrunchCqlBulkRecordWriter getRecordWriter(FileSystem filesystem, JobConf job, String name, Progressable progress) throws IOException {
     throw new CrunchRuntimeException("Use getRecordWriter(org.apache.hadoop.mapreduce.TaskAttemptContext)");
   }

--- a/src/main/java/com/spotify/hdfs2cass/cassandra/utils/CassandraPartitioner.java
+++ b/src/main/java/com/spotify/hdfs2cass/cassandra/utils/CassandraPartitioner.java
@@ -16,9 +16,11 @@
 package com.spotify.hdfs2cass.cassandra.utils;
 
 import org.apache.avro.mapred.AvroKey;
-import org.apache.avro.mapred.AvroValue;
-import org.apache.cassandra.dht.*;
-import org.apache.cassandra.thrift.Mutation;
+import org.apache.cassandra.dht.AbstractPartitioner;
+import org.apache.cassandra.dht.BigIntegerToken;
+import org.apache.cassandra.dht.LongToken;
+import org.apache.cassandra.dht.Murmur3Partitioner;
+import org.apache.cassandra.dht.Token;
 import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.conf.Configuration;
@@ -37,7 +39,7 @@ import java.util.Random;
 /**
  * Uses the cassandra topology to send a key to a particular set of reducers
  */
-public class CassandraPartitioner extends Partitioner<AvroKey<ByteBuffer>, AvroValue<Mutation>> implements Configurable, Serializable {
+public class CassandraPartitioner extends Partitioner<AvroKey<ByteBuffer>, Object> implements Configurable, Serializable {
 
   private static final Logger logger = LoggerFactory.getLogger(CassandraPartitioner.class);
 
@@ -51,11 +53,8 @@ public class CassandraPartitioner extends Partitioner<AvroKey<ByteBuffer>, AvroV
   private Random random;
   private Configuration conf;
 
-  public CassandraPartitioner() {
-  }
-
   @Override
-  public int getPartition(AvroKey<ByteBuffer> key, AvroValue<Mutation> value, int numReducers) {
+  public int getPartition(AvroKey<ByteBuffer> key, Object value, int numReducers) {
     if (distributeRandomly) {
       return reducers.get(random.nextInt(reducers.size()));
     }

--- a/src/main/java/com/spotify/hdfs2cass/crunch/cql/CQLConverter.java
+++ b/src/main/java/com/spotify/hdfs2cass/crunch/cql/CQLConverter.java
@@ -19,38 +19,39 @@ import org.apache.crunch.Pair;
 import org.apache.crunch.types.Converter;
 
 import java.nio.ByteBuffer;
-import java.util.Collection;
 
-public class CQLConverter implements Converter<Object, Collection<ByteBuffer>, Pair<Object, Collection<ByteBuffer>>, Pair<Object, Iterable<Collection<ByteBuffer>>>> {
+public class CQLConverter implements Converter<ByteBuffer, CQLRecord, Pair<ByteBuffer, CQLRecord>, Pair<ByteBuffer, Iterable<CQLRecord>>> {
 
   @Override
-  public Pair<Object, Collection<ByteBuffer>> convertInput(Object k, Collection<ByteBuffer> v) {
+  public Pair<ByteBuffer, CQLRecord> convertInput(final ByteBuffer k, final CQLRecord v) {
     return Pair.of(k, v);
   }
 
   @Override
-  public Pair<Object, Iterable<Collection<ByteBuffer>>> convertIterableInput(Object k, Iterable<Collection<ByteBuffer>> v) {
+  public Pair<ByteBuffer, Iterable<CQLRecord>> convertIterableInput(
+      final ByteBuffer k,
+      final Iterable<CQLRecord> v) {
     return Pair.of(k, v);
   }
 
   @Override
-  public Object outputKey(Pair<Object, Collection<ByteBuffer>> value) {
+  public ByteBuffer outputKey(final Pair<ByteBuffer, CQLRecord> value) {
     return value.first();
   }
 
   @Override
-  public Collection<ByteBuffer> outputValue(Pair<Object, Collection<ByteBuffer>> value) {
+  public CQLRecord outputValue(final Pair<ByteBuffer, CQLRecord> value) {
     return value.second();
   }
 
   @Override
-  public Class<Object> getKeyClass() {
-    return Object.class;
+  public Class<ByteBuffer> getKeyClass() {
+    return ByteBuffer.class;
   }
 
   @Override
-  public Class<Collection<ByteBuffer>> getValueClass() {
-    return (Class<Collection<ByteBuffer>>) (Class<?>) Collection.class;
+  public Class<CQLRecord> getValueClass() {
+    return CQLRecord.class;
   }
 
   @Override

--- a/src/main/java/com/spotify/hdfs2cass/crunch/cql/CQLTarget.java
+++ b/src/main/java/com/spotify/hdfs2cass/crunch/cql/CQLTarget.java
@@ -17,8 +17,8 @@ package com.spotify.hdfs2cass.crunch.cql;
 
 import com.google.common.collect.Maps;
 import com.spotify.hdfs2cass.cassandra.cql.CrunchCqlBulkOutputFormat;
-import com.spotify.hdfs2cass.crunch.CrunchConfigHelper;
 import com.spotify.hdfs2cass.cassandra.utils.CassandraParams;
+import com.spotify.hdfs2cass.crunch.CrunchConfigHelper;
 import org.apache.crunch.CrunchRuntimeException;
 import org.apache.crunch.SourceTarget;
 import org.apache.crunch.Target;
@@ -38,7 +38,6 @@ import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
 import java.io.Serializable;
 import java.net.URI;
 import java.nio.ByteBuffer;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -48,7 +47,7 @@ import java.util.Map;
 public class CQLTarget implements MapReduceTarget, Serializable {
   private Map<String, String> extraConf = Maps.newHashMap();
 
-  private URI resource;
+  private final URI resource;
   private final CassandraParams params;
 
   public CQLTarget(final URI resource, final CassandraParams params) {
@@ -113,15 +112,11 @@ public class CQLTarget implements MapReduceTarget, Serializable {
   @Override
   public boolean accept(final OutputHandler handler, final PType<?> pType) {
     if (pType instanceof PTableType) {
-      PTableType pTableType = (PTableType) pType;
+      final PTableType<?, ?> pTableType = (PTableType<?, ?>) pType;
       PType<?> keyType = pTableType.getKeyType();
       PType<?> valueType = pTableType.getValueType();
-      List<PType> subTypes = valueType.getSubTypes();
-
       if (ByteBuffer.class.equals(keyType.getTypeClass())
-          && Collection.class.equals(valueType.getTypeClass())
-          && subTypes.size() == 1
-          && ByteBuffer.class.equals(subTypes.get(0).getTypeClass())) {
+          && CQLRecord.class.equals(valueType.getTypeClass())) {
         handler.configure(this, pType);
         return true;
       }
@@ -143,6 +138,4 @@ public class CQLTarget implements MapReduceTarget, Serializable {
   public String toString() {
     return resource.toString();
   }
-
-
 }


### PR DESCRIPTION
When constructing a CQLRecord from a binary key and column values, it
is easy to get the partitioning key wrong (for example by forgetting
to include some components, or getting the encoding wrong). This
throws the partitioner off, and causes records to be sent to
essentially random reducers. We end up with all reducers streaming to
all Cassandra nodes, which works but is very undesirable (creating way
too many sstables on each node).

Fortunately, the CQL record together with the schema contain all
information needed to build the partitioning key. This patch lets the
framework calculate the partitioning key, simplifying user code.