### PR TITLE
Fix bug in composite key handling

### DIFF
--- a/src/main/java/com/spotify/hdfs2cass/cassandra/utils/CassandraClusterInfo.java
+++ b/src/main/java/com/spotify/hdfs2cass/cassandra/utils/CassandraClusterInfo.java
@@ -71,6 +71,7 @@ public class CassandraClusterInfo implements Serializable {
     }
 
     // ask for some metadata
+    logger.info("getting cluster metadata for {}.{}", keyspace, columnFamily);
     final TableMetadata tableMetadata;
     try (final Cluster cluster = clusterBuilder.build()) {
       Metadata clusterMetadata = cluster.getMetadata();
@@ -97,8 +98,9 @@ public class CassandraClusterInfo implements Serializable {
       for (j = 0; j < columns.size(); j++) {
         if (columns.get(j).getName().equals(keyColName)) {
           partitionKeyIndexes[i] = j;
+          logger.info("partition key column {} index {}", keyColName, j);
+          break;
         }
-        break;
       }
       if (j == columns.size()) {
         throw new CrunchRuntimeException("no matching column for key " + keyColName);


### PR DESCRIPTION
A misplaced early exit from a loop caused only the first column of a
composite partition key to ever be considered for sorting. This could
cause the job to fail on multiple records with the same first key
column.